### PR TITLE
fix eslint: adjust eslintrc.js file, add additional dependencies to eslint precommit hook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,25 +3,11 @@ module.exports = {
   env: {
     node: true
   },
-  extends: ['plugin:vue/essential', 'eslint:recommended', '@vue/prettier'],
-  parserOptions: {
-    parser: 'babel-eslint'
-  },
+  extends: ['plugin:vue/essential', 'eslint:recommended'],
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'prettier/prettier': [
-      'error',
-      {
-        endOfLine: 'auto',
-        tabWidth: 2,
-        printWidth: 100,
-        singleQuote: true,
-        trailingComma: 'none',
-        bracketSameLine: true,
-        vueIndentScriptAndStyle: true
-      }
-    ]
+    'vue/multi-word-component-names': 'off',
   },
   overrides: [
     {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,5 +55,9 @@ repos:
     rev: v8.56.0
     hooks:
     -   id: eslint
+        additional_dependencies:
+        -   eslint@8.56.0
+        -   eslint-plugin-vue@9.20.1
+        -   "@babel/eslint-parser@7.15.8"
         files: \.(js|css|html|vue|ts|jsx)$
         types: [file]


### PR DESCRIPTION
Added some necessary depedencies to the eslint pre commit hook and adjusted the eslintrc.js file. When we merge this in order for it to work we need to also:

- on the admin-panel, delete the eslintrc.js file.
- on the public-frontend, delete the eslintrc.js file, and rename the babel.config.js file to babel.config.cjs in order to convert this to a common js module 

Let me know what you think, and when this is merge i will proceed to make the adjustments mentioned above as well.