### PR TITLE
feat: disable no-v-model argument eslint error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     'no-console': 'error',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'vue/multi-word-component-names': 'off',
+    'vue/no-v-model-argument': 'off',
   },
   overrides: [
     {


### PR DESCRIPTION
Disabling eslint vue/no-v-model argument error, which doesn't allow passing arguments to v-model.