### PR TITLE
fix: Disable "no-unused-vars" eslint error for "props" variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,11 @@ module.exports = {
     'vue/no-v-model-argument': 'off',
     'vue/no-multiple-template-root': 'off',
     'vue/require-valid-default-prop': 'off',
-    'vue/require-v-for-key': 'off'
+    'vue/require-v-for-key': 'off',
+    'no-unused-vars': ['error', { 
+      'varsIgnorePattern': '^props$',
+      'argsIgnorePattern': '^_'
+    }]
   },
   overrides: [
     {


### PR DESCRIPTION
On a lot of our vue.js files we define props that might not be used but it's still important to know which props are passed in a component when working on it so I added this rule to bypass any variable defined that matches the "props" wording, using eslint's [varsIgnorePattern](https://eslint.org/docs/latest/rules/no-unused-vars#varsignorepattern) for definitions, and [argsIgnorePattern](https://eslint.org/docs/latest/rules/no-unused-vars#argsignorepattern) for function arguments.